### PR TITLE
Update pre-commit hooks and ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,10 +62,10 @@ repos:
     hooks:
       - id: blacken-docs
         args: [-S, -l, '120']
-        additional_dependencies: [black==23.3.0]
+        additional_dependencies: [black==25.12.0]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix, --show-source, --show-fixes]
+        args: [--fix, --exit-non-zero-on-fix, --show-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,21 +51,9 @@ repos:
     hooks:
       - id: yamllint
 
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
-    hooks:
-      - id: black
-        language_version: python3
-
-  - repo: https://github.com/asottile/blacken-docs
-    rev: 1.20.0
-    hooks:
-      - id: blacken-docs
-        args: [-S, -l, '120']
-        additional_dependencies: [black==25.12.0]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+      - id: ruff-format

--- a/app/process.py
+++ b/app/process.py
@@ -64,7 +64,7 @@ def process_people_list_get(ticket_names, ticket_ids):
     """Process GET requests for the list of participants."""
     session['people_csv_html'] = convert_people_list_to_html(session['people'])
     table_labels = [
-        f'td:nth-of-type({idx+1}):before {{ content: "{key}"; }}' for idx, key in enumerate(session['people'][0])
+        f'td:nth-of-type({idx + 1}):before {{ content: "{key}"; }}' for idx, key in enumerate(session['people'][0])
     ]
     session['ticket_names_str'] = str(ticket_names)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,7 @@ select = ['F',   # pyflakes
           'PL',  # pylint
           'RUF', # ruff-specific rules
 ]
-ignore = ['ANN101', # missing-type-self
-          'D203',   # one-blank-line-before-class
+ignore = ['D203',   # one-blank-line-before-class
           'D212',   # multi-line-summary-first-line
           'S603'    # subprocess-without-shell-equals-true
 ]
@@ -125,30 +124,6 @@ quote-style = 'preserve'
             '*_test.py',
             '*_fixtures.py'
         ]
-
-# --------------------------------------
-
-[tool.pylint]
-    [tool.pylint.master]
-    ignore-patterns = [
-        '.*_test.py',
-        '.*_fixtures.py',
-    ]
-
-    init-hook = '''from pylint.config import find_default_config_files;\
-    import os, sys; \
-    sys.path.append(os.path.dirname(list(find_default_config_files())[0]))'''
-
-    [tool.pylint.basic]
-    good-names = ['COMMITTEE_LIST']
-
-    [tool.pylint.format]
-    max-line-length = 120
-
-    [tool.pylint.typecheck]
-    ignored-modules = [
-        'wsgi',
-    ]
 
 # --------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,12 +114,8 @@ multiline-quotes = 'single'
 [tool.ruff.lint.pydocstyle]
 convention = 'google'
 
-# --------------------------------------
-
-[tool.black]
-line-length = 120
-target-version = ['py39', 'py310', 'py311']
-skip-string-normalization = true
+[tool.ruff.format]
+quote-style = 'preserve'
 
 # --------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ include = ['aluso_labels']
 line-length = 120
 target-version = 'py38'
 
+[tool.ruff.lint]
 select = ['F',   # pyflakes
           'E',   # pycodestyle
           'W',   # pycodestyle
@@ -95,24 +96,22 @@ ignore = ['ANN101', # missing-type-self
           'S603'    # subprocess-without-shell-equals-true
 ]
 
-[tool.ruff.per-file-ignores]
-
+[tool.ruff.lint.per-file-ignores]
 'tests/python/*.py' = ['S101', 'SLF001', 'PLR0913', 'PLR2004', 'D']
 
-
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 allow-star-arg-any = true
 ignore-fully-untyped = true
 mypy-init-return = true
 suppress-dummy-args = true
 suppress-none-returning = true
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 docstring-quotes = 'double'
 inline-quotes = 'single'
 multiline-quotes = 'single'
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = 'google'
 
 # --------------------------------------


### PR DESCRIPTION
- Remove deprecated --show-source flag from ruff (replaced by default
  --output-format=full in ruff v0.5.0+)
- Update blacken-docs to use black==25.12.0 for consistency
- Migrate ruff config to new lint section format:
  - [tool.ruff.lint] for select/ignore
  - [tool.ruff.lint.per-file-ignores]
  - [tool.ruff.lint.flake8-annotations]
  - [tool.ruff.lint.flake8-quotes]
  - [tool.ruff.lint.pydocstyle]